### PR TITLE
Fix: UV-less cylinders don't have sides

### DIFF
--- a/Scripts/MeshDraftPrimitives.cs
+++ b/Scripts/MeshDraftPrimitives.cs
@@ -412,6 +412,7 @@ namespace ProceduralToolkit
             {
                 draft.AddTriangleFan(lowerRing, Vector3.down, true);
                 draft.AddTriangleFan(upperRing, Vector3.up);
+                draft.AddTriangleStrip(strip, stripNormals);
             }
             return draft;
         }


### PR DESCRIPTION
This seems like a simple oversight, but here it is. Before this fix, spawning a Cylinder primitive with `generateUV = false` would create end cap faces, but no long sides. This PR fixes that.